### PR TITLE
Update TournamentOverlay.tsx

### DIFF
--- a/src/pages/TournamentOverlay.tsx
+++ b/src/pages/TournamentOverlay.tsx
@@ -86,7 +86,7 @@ const TournamentOverlay = () => {
         top: "0",
         left: "0",
         right: "0",
-        backgroundColor: 'rgba(0, 0, 0, 1.0)',        // backgroundColor: "rgba(0,0,0,0.7)",
+        backgroundColor: 'rgba(0, 0, 0, 0)',        // backgroundColor: "rgba(0,0,0,0.7)",
         textAlign: "center",
         width: '1920px', height: '1080px'
       }}

--- a/src/pages/TournamentOverlay.tsx
+++ b/src/pages/TournamentOverlay.tsx
@@ -86,7 +86,7 @@ const TournamentOverlay = () => {
         top: "0",
         left: "0",
         right: "0",
-        backgroundColor: 'rgba(0, 255, 0, 1.0)',        // backgroundColor: "rgba(0,0,0,0.7)",
+        backgroundColor: 'rgba(0, 0, 0, 1.0)',        // backgroundColor: "rgba(0,0,0,0.7)",
         textAlign: "center",
         width: '1920px', height: '1080px'
       }}


### PR DESCRIPTION
Remove "greenscreen" from TournamentOverlay in preperation to Oslo Masters <3. The goal is transparent background.