### PR TITLE
Legge til kommentar i Loggen

### DIFF
--- a/src/components/eventFunctions.tsx
+++ b/src/components/eventFunctions.tsx
@@ -138,6 +138,19 @@ export const setClearMessageEvent = (userId: string): Event => {
     }
 }
 
+export const createCommentEvent = (text: string, userId: string): Event => {
+    return {
+        id: v4(),
+        eventType: EventType.Comment,
+        team: TeamType.None,
+        playerId: 0,
+        timestamp: Date.now(),
+        undone: "",
+        author: userId,
+        reference: text.trim()
+    }
+}
+
 export const createUndoEvent = (events: Event[], userId: string): Event => {
     const reversedEvents = [...events].reverse();
     const undoneEventIndex = reversedEvents.findIndex((event: Event) => !event.undone && event.eventType !== EventType.Undo);
@@ -169,7 +182,7 @@ export const createUndoEvent = (events: Event[], userId: string): Event => {
 
 export const getLastValidEvent = (events: Event[]): Event | null => {
     const reversedEvents = events.slice().reverse();
-    const undoneEventIndex = reversedEvents.findIndex((event: Event) => !event.undone && event.eventType !== EventType.Undo);
+    const undoneEventIndex = reversedEvents.findIndex((event: Event) => !event.undone && event.eventType !== EventType.Undo && event.eventType !== EventType.Comment);
 
     if (undoneEventIndex < 0) {
         return null

--- a/src/components/eventList.tsx
+++ b/src/components/eventList.tsx
@@ -1,20 +1,32 @@
 import React, { useState } from "react";
 import { Event, EventType, TeamType } from "./types";
-import { Box, Button, Grid, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Typography } from "@mui/material";
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Grid, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Typography } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../store/store";
 import { addEvent } from "../store/match/reducer";
 import { createCommentEvent } from "./eventFunctions";
 import moment from "moment";
 
+const REMARK_MAX_LENGTH = 200;
 
 const EventList: React.FC = () => {
   const match = useAppSelector((state) => state.match);
   const dispatch = useAppDispatch();
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
+  const [isRemarkDialogOpen, setIsRemarkDialogOpen] = useState<boolean>(false);
   const [commentText, setCommentText] = useState<string>("");
 
   const toggleExpansion = () => {
     setIsExpanded((expanded) => !expanded);
+  };
+
+  const openRemarkDialog = () => {
+    setCommentText("");
+    setIsRemarkDialogOpen(true);
+  };
+
+  const closeRemarkDialog = () => {
+    setIsRemarkDialogOpen(false);
+    setCommentText("");
   };
 
   const submitComment = () => {
@@ -23,6 +35,7 @@ const EventList: React.FC = () => {
       return;
     }
     dispatch(addEvent({ matchId: match.matchId, id: match.id, event: createCommentEvent(trimmed, match.authUserId) }));
+    setIsRemarkDialogOpen(false);
     setCommentText("");
   };
 
@@ -165,24 +178,13 @@ const EventList: React.FC = () => {
           </TableBody>
         </Table>
       </TableContainer>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, justifyContent: 'center', marginTop: 1, paddingTop: 1, borderTop: "1px solid rgba(0,0,0,0.1)" }}>
-        <TextField
-          size="small"
-          variant="standard"
-          placeholder="Add Remarks"
-          value={commentText}
-          onChange={(e) => setCommentText(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") { submitComment(); } }}
-          slotProps={{ htmlInput: { maxLength: 200 } }}
-          sx={{ maxWidth: 220 }}
-        />
+      <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: 1, paddingTop: 1, borderTop: "1px solid rgba(0,0,0,0.1)" }}>
         <Button
           size="small"
-          onClick={submitComment}
-          disabled={!commentText.trim()}
-          sx={{ color: "rgba(28,28,30,0.65)", fontWeight: 700, minWidth: 'auto' }}
+          onClick={openRemarkDialog}
+          sx={{ color: "rgba(28,28,30,0.65)", fontWeight: 700 }}
         >
-          Add
+          Add Remark
         </Button>
       </Box>
       </Box>
@@ -191,6 +193,31 @@ const EventList: React.FC = () => {
           {isExpanded ? "Show less" : "Show more"}
         </Button>
       )}
+
+      <Dialog open={isRemarkDialogOpen} onClose={closeRemarkDialog} fullWidth maxWidth="xs">
+        <DialogTitle>Add Remark</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            multiline
+            minRows={3}
+            variant="outlined"
+            placeholder="Comment"
+            value={commentText}
+            onChange={(e) => setCommentText(e.target.value)}
+            slotProps={{ htmlInput: { maxLength: REMARK_MAX_LENGTH } }}
+            sx={{ marginTop: 1 }}
+          />
+          <Typography variant="caption" sx={{ display: 'block', textAlign: 'right', marginTop: 0.5, color: "rgba(28,28,30,0.55)" }}>
+            {commentText.length} / {REMARK_MAX_LENGTH}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeRemarkDialog}>Cancel</Button>
+          <Button onClick={submitComment} disabled={!commentText.trim()} variant="contained">Save</Button>
+        </DialogActions>
+      </Dialog>
     </Grid>
   );
 };

--- a/src/components/eventList.tsx
+++ b/src/components/eventList.tsx
@@ -129,7 +129,7 @@ const EventList: React.FC = () => {
     const localTime = moment(event.timestamp).format("HH.mm:ss");
     const elapsed = formatElapsed(event.timestamp - startTimestamp);
     const eventName = event.eventType === EventType.Comment
-      ? `Remark: ${event.reference}`
+      ? event.reference
       : `${eventTypeToString(event.eventType)}${event.team === TeamType.None ? "" : ` ${teamToString(event.team)}`}`;
     const standing = `${displayHome}-${displayAway}`;
 
@@ -205,7 +205,7 @@ const EventList: React.FC = () => {
             variant="outlined"
             placeholder="Comment"
             value={commentText}
-            onChange={(e) => setCommentText(e.target.value)}
+            onChange={(e) => setCommentText(e.target.value.slice(0, REMARK_MAX_LENGTH))}
             slotProps={{ htmlInput: { maxLength: REMARK_MAX_LENGTH } }}
             sx={{ marginTop: 1 }}
           />

--- a/src/components/eventList.tsx
+++ b/src/components/eventList.tsx
@@ -1,16 +1,29 @@
 import React, { useState } from "react";
 import { Event, EventType, TeamType } from "./types";
-import { Box, Button, Grid, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from "@mui/material";
-import { useAppSelector } from "../store/store";
+import { Box, Button, Grid, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Typography } from "@mui/material";
+import { useAppDispatch, useAppSelector } from "../store/store";
+import { addEvent } from "../store/match/reducer";
+import { createCommentEvent } from "./eventFunctions";
 import moment from "moment";
 
 
 const EventList: React.FC = () => {
   const match = useAppSelector((state) => state.match);
+  const dispatch = useAppDispatch();
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
+  const [commentText, setCommentText] = useState<string>("");
 
   const toggleExpansion = () => {
     setIsExpanded((expanded) => !expanded);
+  };
+
+  const submitComment = () => {
+    const trimmed = commentText.trim();
+    if (!trimmed) {
+      return;
+    }
+    dispatch(addEvent({ matchId: match.matchId, id: match.id, event: createCommentEvent(trimmed, match.authUserId) }));
+    setCommentText("");
   };
 
   const formatElapsed = (milliseconds: number): string => {
@@ -54,7 +67,7 @@ const EventList: React.FC = () => {
   };
 
   const timelineEvents = [...match.events]
-    .filter((event) => !event.undone && (event.eventType === EventType.Score || event.eventType === EventType.Timeout))
+    .filter((event) => !event.undone && (event.eventType === EventType.Score || event.eventType === EventType.Timeout || event.eventType === EventType.Comment))
     .sort((a, b) => a.timestamp - b.timestamp);
 
   const startTimestamp = timelineEvents.length > 0 ? timelineEvents[0].timestamp : 0;
@@ -102,7 +115,9 @@ const EventList: React.FC = () => {
 
     const localTime = moment(event.timestamp).format("HH.mm:ss");
     const elapsed = formatElapsed(event.timestamp - startTimestamp);
-    const eventName = `${eventTypeToString(event.eventType)}${event.team === TeamType.None ? "" : ` ${teamToString(event.team)}`}`;
+    const eventName = event.eventType === EventType.Comment
+      ? `Remark: ${event.reference}`
+      : `${eventTypeToString(event.eventType)}${event.team === TeamType.None ? "" : ` ${teamToString(event.team)}`}`;
     const standing = `${displayHome}-${displayAway}`;
 
     return {
@@ -150,6 +165,26 @@ const EventList: React.FC = () => {
           </TableBody>
         </Table>
       </TableContainer>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, justifyContent: 'center', marginTop: 1, paddingTop: 1, borderTop: "1px solid rgba(0,0,0,0.1)" }}>
+        <TextField
+          size="small"
+          variant="standard"
+          placeholder="Add Remarks"
+          value={commentText}
+          onChange={(e) => setCommentText(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") { submitComment(); } }}
+          slotProps={{ htmlInput: { maxLength: 200 } }}
+          sx={{ maxWidth: 220 }}
+        />
+        <Button
+          size="small"
+          onClick={submitComment}
+          disabled={!commentText.trim()}
+          sx={{ color: "rgba(28,28,30,0.65)", fontWeight: 700, minWidth: 'auto' }}
+        >
+          Add
+        </Button>
+      </Box>
       </Box>
       {timelineRows.length > 3 && (
         <Button variant="contained" onClick={toggleExpansion} sx={{ marginTop: 1.5, borderRadius: '10px', fontWeight: 700, minWidth: 132, backgroundColor: '#1a6bba', '&:hover': { backgroundColor: '#15599d' } }}>

--- a/src/components/types.tsx
+++ b/src/components/types.tsx
@@ -50,6 +50,7 @@ export enum EventType {
   SetFinalized = "SET_FINALIZED",
   MatchFinalized = "MATCH_FINALIZED",
   ClearMessage = "CLEAR_MESSAGE",
+  Comment = "COMMENT",
 }
 
 export enum TeamType {

--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -83,26 +83,21 @@ function Match() {
 
       {getActiveDisplay(match) === DisplayType.TeamTimeout && <Scoreboard />}
       {getActiveDisplay(match) === DisplayType.TeamTimeout && <TeamTimeout team={getLastValidEvent(match.events)?.team ?? TeamType.None} />}
-      {getActiveDisplay(match) === DisplayType.TeamTimeout && <EventList />}
 
 
       {getActiveDisplay(match) === DisplayType.TechnicalTimeout && <Scoreboard />}
       {getActiveDisplay(match) === DisplayType.TechnicalTimeout && <TechnicalTimeout startTime={getLastValidEvent(match.events)?.timestamp ?? 0} />}
-      {getActiveDisplay(match) === DisplayType.TechnicalTimeout && <EventList />}
 
 
       {getActiveDisplay(match) === DisplayType.SwitchSides && <Scoreboard />}
       {getActiveDisplay(match) === DisplayType.SwitchSides && <SwitchSides />}
 
       {getActiveDisplay(match) === DisplayType.SetFinished && <SetFinished />}
-      {getActiveDisplay(match) === DisplayType.SetFinished && <EventList />}
 
       {getActiveDisplay(match) === DisplayType.MatchFinished && <MatchFinished />}
-      {getActiveDisplay(match) === DisplayType.MatchFinished && <EventList />}
 
 
       {getActiveDisplay(match) === DisplayType.MatchFinalized && <MatchFinalized />}
-      {getActiveDisplay(match) === DisplayType.MatchFinalized && <EventList />}
 
       {getActiveDisplay(match) === DisplayType.Loading && < Loader />}
     </main>

--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -82,12 +82,12 @@ function Match() {
 
 
       {getActiveDisplay(match) === DisplayType.TeamTimeout && <Scoreboard />}
-      {getActiveDisplay(match) === DisplayType.TeamTimeout && <TeamTimeout team={match.events.slice().reverse()[0].team} />}
+      {getActiveDisplay(match) === DisplayType.TeamTimeout && <TeamTimeout team={getLastValidEvent(match.events)?.team ?? TeamType.None} />}
       {getActiveDisplay(match) === DisplayType.TeamTimeout && <EventList />}
 
 
       {getActiveDisplay(match) === DisplayType.TechnicalTimeout && <Scoreboard />}
-      {getActiveDisplay(match) === DisplayType.TechnicalTimeout && <TechnicalTimeout startTime={match.events.slice().reverse()[0].timestamp} />}
+      {getActiveDisplay(match) === DisplayType.TechnicalTimeout && <TechnicalTimeout startTime={getLastValidEvent(match.events)?.timestamp ?? 0} />}
       {getActiveDisplay(match) === DisplayType.TechnicalTimeout && <EventList />}
 
 

--- a/tests/eventFunctions.test.ts
+++ b/tests/eventFunctions.test.ts
@@ -1,0 +1,46 @@
+import {
+    callTimeoutEvent,
+    createAddPointEvent,
+    createCommentEvent,
+    createUndoEvent,
+    getLastValidEvent,
+} from "../src/components/eventFunctions";
+import { TeamType } from "../src/components/types";
+
+const USER = "test-user";
+
+describe("getLastValidEvent", () => {
+    it("returns null for an empty event list", () => {
+        expect(getLastValidEvent([])).toBeNull();
+    });
+
+    it("returns the most recent event", () => {
+        const e1 = createAddPointEvent(TeamType.Home, USER);
+        const e2 = callTimeoutEvent(TeamType.Away, USER);
+        expect(getLastValidEvent([e1, e2])).toEqual(e2);
+    });
+
+    it("skips a trailing UNDO event and returns the event before it", () => {
+        const timeout = callTimeoutEvent(TeamType.Home, USER);
+        const undo = createUndoEvent([timeout], USER);
+        expect(getLastValidEvent([timeout, undo])).toEqual(timeout);
+    });
+
+    it("skips a trailing COMMENT event and returns the event before it", () => {
+        const timeout = callTimeoutEvent(TeamType.Home, USER);
+        const comment = createCommentEvent("note", USER);
+        expect(getLastValidEvent([timeout, comment])).toEqual(timeout);
+    });
+
+    it("skips an already-undone event", () => {
+        const e1 = createAddPointEvent(TeamType.Home, USER);
+        const e2 = { ...createAddPointEvent(TeamType.Away, USER), undone: "some-undo-id" };
+        expect(getLastValidEvent([e1, e2])).toEqual(e1);
+    });
+
+    it("returns null when only COMMENT/UNDO/undone events exist", () => {
+        const comment = createCommentEvent("note", USER);
+        const undo = createUndoEvent([], USER);
+        expect(getLastValidEvent([comment, undo])).toBeNull();
+    });
+});

--- a/tests/match-reducer.test.ts
+++ b/tests/match-reducer.test.ts
@@ -1,6 +1,7 @@
 import {
     callTimeoutEvent,
     createAddPointEvent,
+    createCommentEvent,
     finalizeMatchEvent,
     finalizeSetEvent,
     pickTeamColorEvent,
@@ -217,6 +218,35 @@ describe("evaluateEvents — configuration events", () => {
         const event = pickTeamColorEvent(TeamType.Home, "#abcdef", USER);
         expect(event.eventType).toBe(EventType.PickColor);
         expect(event.reference).toBe("#abcdef");
+    });
+
+    it("COMMENT event is stored via createCommentEvent (reference field holds trimmed text)", () => {
+        const event = createCommentEvent("  green card issued  ", USER);
+        expect(event.eventType).toBe(EventType.Comment);
+        expect(event.reference).toBe("green card issued");
+    });
+
+    it("a COMMENT event does not affect score or set state", () => {
+        let state = { ...initMatchState };
+        state = scorePoints(state, TeamType.Home, 3);
+        state = matchReducer(state, insertEvent(createCommentEvent("note", USER)));
+        state = matchReducer(state, evaluateEvents());
+
+        expect(state.currentScore[TeamType.Home]).toBe(3);
+        expect(state.currentScore[TeamType.Away]).toBe(0);
+        expect(state.finished).toBe(false);
+    });
+
+    it("a COMMENT event does not clear an in-flight userMessage", () => {
+        let state = { ...initMatchState };
+        // Score 6 combined points to trigger the "switch sides" warning
+        state = scorePoints(state, TeamType.Home, 3);
+        state = scorePoints(state, TeamType.Away, 3);
+        expect(state.userMessage).toBe("switch sides");
+
+        state = matchReducer(state, insertEvent(createCommentEvent("note", USER)));
+        state = matchReducer(state, evaluateEvents());
+        expect(state.userMessage).toBe("switch sides");
     });
 });
 


### PR DESCRIPTION
Lar deg legge til en kommentar som dukker opp med timestamp i loggen.
Du finner den nederst under loggen. Den kan være litt vanskelig å finne(?), men det tar ikke fokuset vekk fra de viktige elementene på siden. Håpet er at den er lett og finne når du trenger den, men du ikke ser den når du ikke trenger den.  
 
Begrunnelse: legge til kommentar om rød kort etc. 

Kode:
Det er endel kode som går rundt at man kan legge til en kommentar når man får en melding ala "side switch" og lignende. 

Usikker på om dette er løst på best måte. En alternativ implmentasjon kan istedenfor å legge til COMMENT i en filter liste (2 ganger), heller sjekke om  CLEAR_DISPLAY (eller hva eventet het)  er senere enn siste poeng som er lagt til. 

  