### PR TITLE
feat: Legge til velgfri draktnumber på spillere

### DIFF
--- a/src/components/scoreboard.tsx
+++ b/src/components/scoreboard.tsx
@@ -9,7 +9,7 @@ import {
 import { useAppSelector } from '../store/store';
 import { TeamType, Event, EventType } from './types';
 import Grid from "@mui/material/Grid"
-import { getInitials } from "../util/names";
+import { getInitials, withJerseyNumber } from "../util/names";
 import { matchState } from "../store/types";
 import { ScoreBox } from "./scoreboard/scoreBox";
 
@@ -63,7 +63,7 @@ export function Scoreboard() {
               textDecorationThickness: '2px',
               textUnderlineOffset: '4px',
               textDecoration: (getServer(match.events, leftTeam) === 1) ? "underline" : "none"
-            }}> {getInitials(getPlayer(match, 1, leftTeam))} </Typography>
+            }}> {withJerseyNumber(getInitials(getPlayer(match, 1, leftTeam)), getPlayerNumber(match, 1, leftTeam))} </Typography>
           </Grid>
           <Grid size={1} sx={{ color: '#1c1c1e' }}>
             {(getServer(match.events, rightTeam) === 1) && <ArrowForwardIos sx={{ fontSize: 16 }} />}
@@ -76,7 +76,7 @@ export function Scoreboard() {
               textDecorationThickness: '2px',
               textUnderlineOffset: '4px',
               textDecoration: (getServer(match.events, rightTeam) === 1) ? "underline" : "none"
-            }}> {getInitials(getPlayer(match, 1, rightTeam))}</Typography>
+            }}> {withJerseyNumber(getInitials(getPlayer(match, 1, rightTeam)), getPlayerNumber(match, 1, rightTeam))}</Typography>
           </Grid>
 
           <Grid size={6} sx={{ textAlign: 'right' }}>
@@ -86,7 +86,7 @@ export function Scoreboard() {
               textDecorationThickness: '2px',
               textUnderlineOffset: '4px',
               textDecoration: (getServer(match.events, leftTeam) === 2) ? "underline" : "none"
-            }}> {getInitials(getPlayer(match, 2, leftTeam))}</Typography>
+            }}> {withJerseyNumber(getInitials(getPlayer(match, 2, leftTeam)), getPlayerNumber(match, 2, leftTeam))}</Typography>
 
           </Grid>
           <Grid size={1} sx={{ color: '#1c1c1e' }}>
@@ -100,7 +100,7 @@ export function Scoreboard() {
               textDecorationThickness: '2px',
               textUnderlineOffset: '4px',
               textDecoration: (getServer(match.events, rightTeam) === 2) ? "underline" : "none"
-            }}> {getInitials(getPlayer(match, 2, rightTeam))}</Typography>
+            }}> {withJerseyNumber(getInitials(getPlayer(match, 2, rightTeam)), getPlayerNumber(match, 2, rightTeam))}</Typography>
           </Grid>
         </Grid>
       </Grid>
@@ -138,6 +138,22 @@ export const getPlayer = (match: matchState, playerId: number, teamType: TeamTyp
       return match.awayTeam.player1Name
     } else {
       return match.awayTeam.player2Name
+    }
+  }
+}
+
+export const getPlayerNumber = (match: matchState, playerId: number, teamType: TeamType): string | undefined => {
+  if (teamType === TeamType.Home) {
+    if (playerId === 1) {
+      return match.homeTeam.player1Number
+    } else {
+      return match.homeTeam.player2Number
+    }
+  } else {
+    if (playerId === 1) {
+      return match.awayTeam.player1Number
+    } else {
+      return match.awayTeam.player2Number
     }
   }
 }

--- a/src/components/scoreboard/addTeam.tsx
+++ b/src/components/scoreboard/addTeam.tsx
@@ -29,6 +29,8 @@ export function AddTeam({ teamType }: AddTeamProps) {
 
   const [player1Name, setPlayer1Name] = useState(team.player1Name);
   const [player2Name, setPlayer2Name] = useState(team.player2Name);
+  const [player1Number, setPlayer1Number] = useState(team.player1Number ?? "");
+  const [player2Number, setPlayer2Number] = useState(team.player2Number ?? "");
 
   function handlePlayer1Name(name: string) {
     setPlayer1Name(name)
@@ -38,16 +40,28 @@ export function AddTeam({ teamType }: AddTeamProps) {
     setPlayer2Name(name)
   }
 
+  function handlePlayer1Number(value: string) {
+    setPlayer1Number(value.replace(/\D/g, '').slice(0, 2))
+  }
+
+  function handlePlayer2Number(value: string) {
+    setPlayer2Number(value.replace(/\D/g, '').slice(0, 2))
+  }
+
   function handleSubmit() {
     if (teamType === TeamType.Home) {
       dispatch(addHomeTeam({
         player1Name: player1Name,
         player2Name: player2Name,
+        player1Number: player1Number,
+        player2Number: player2Number,
       }))
     } else {
       dispatch(addAwayTeam({
         player1Name: player1Name,
         player2Name: player2Name,
+        player1Number: player1Number,
+        player2Number: player2Number,
       }))
     }
   }
@@ -65,23 +79,44 @@ export function AddTeam({ teamType }: AddTeamProps) {
         <Typography sx={{ fontSize: 28 }}>Add {teamType === TeamType.Home ? "home" : "away"} team!</Typography>
       </Grid>
       <Grid size={12}>
-
-        <TextField
-          sx={{
-            width: 1, height: 64
-          }}
-          label="Player 1"
-          value={player1Name}
-          onChange={(e) => handlePlayer1Name(e.target.value)}
-        />
-        <TextField
-          sx={{
-            width: 1, height: 64
-          }}
-          label="Player 2"
-          value={player2Name}
-          onChange={(e) => handlePlayer2Name(e.target.value)}
-        />
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <TextField
+            sx={{
+              flex: 3, height: 64
+            }}
+            label="Player 1"
+            value={player1Name}
+            onChange={(e) => handlePlayer1Name(e.target.value)}
+          />
+          <TextField
+            sx={{
+              flex: 1, height: 64
+            }}
+            label="Number"
+            value={player1Number}
+            onChange={(e) => handlePlayer1Number(e.target.value)}
+            slotProps={{ htmlInput: { inputMode: 'numeric', maxLength: 2 } }}
+          />
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+          <TextField
+            sx={{
+              flex: 3, height: 64
+            }}
+            label="Player 2"
+            value={player2Name}
+            onChange={(e) => handlePlayer2Name(e.target.value)}
+          />
+          <TextField
+            sx={{
+              flex: 1, height: 64
+            }}
+            label="Number"
+            value={player2Number}
+            onChange={(e) => handlePlayer2Number(e.target.value)}
+            slotProps={{ htmlInput: { inputMode: 'numeric', maxLength: 2 } }}
+          />
+        </Box>
       </Grid>
       <Grid size={{ xs: 12, md: 6 }} sx={{ textAlign: 'left' }}>
         <Button variant="contained" onClick={handleSubmit.bind(null)}

--- a/src/components/scoreboard/initMatch.tsx
+++ b/src/components/scoreboard/initMatch.tsx
@@ -5,7 +5,7 @@ import { initMatch, resetTeamColor } from '../../store/match/reducer';
 import { useAppDispatch, useAppSelector } from '../../store/store';
 import { TeamType } from './../types';
 import { getTextColorFromBackground } from "../../util/color";
-import { getInitials } from "../../util/names";
+import { getInitials, withJerseyNumber } from "../../util/names";
 import { colors } from "../../theme";
 
 export function InitMatch() {
@@ -22,8 +22,18 @@ export function InitMatch() {
       id: v4(),
       awayColor: match.teamColor[TeamType.Away],
       homeColor: match.teamColor[TeamType.Home],
-      awayTeam: { player1Name: match.awayTeam.player1Name, player2Name: match.awayTeam.player2Name },
-      homeTeam: { player1Name: match.homeTeam.player1Name, player2Name: match.homeTeam.player2Name },
+      awayTeam: {
+        player1Name: match.awayTeam.player1Name,
+        player2Name: match.awayTeam.player2Name,
+        player1Number: match.awayTeam.player1Number ?? "",
+        player2Number: match.awayTeam.player2Number ?? "",
+      },
+      homeTeam: {
+        player1Name: match.homeTeam.player1Name,
+        player2Name: match.homeTeam.player2Name,
+        player1Number: match.homeTeam.player1Number ?? "",
+        player2Number: match.homeTeam.player2Number ?? "",
+      },
       matchId: match.matchId,
       tournamentId: match.tournamentId,
       timestamp: Date.now(),
@@ -51,16 +61,16 @@ export function InitMatch() {
       <Box sx={{ display: "flex", gap: 2, mb: 5 }}>
         <TeamButton
           label={[
-            getInitials(match.homeTeam.player1Name),
-            getInitials(match.homeTeam.player2Name),
+            withJerseyNumber(getInitials(match.homeTeam.player1Name), match.homeTeam.player1Number),
+            withJerseyNumber(getInitials(match.homeTeam.player2Name), match.homeTeam.player2Number),
           ]}
           color={match.teamColor[TeamType.Home]}
           onClick={() => setTeamColors(TeamType.Home)}
         />
         <TeamButton
           label={[
-            getInitials(match.awayTeam.player1Name),
-            getInitials(match.awayTeam.player2Name),
+            withJerseyNumber(getInitials(match.awayTeam.player1Name), match.awayTeam.player1Number),
+            withJerseyNumber(getInitials(match.awayTeam.player2Name), match.awayTeam.player2Number),
           ]}
           color={match.teamColor[TeamType.Away]}
           onClick={() => setTeamColors(TeamType.Away)}

--- a/src/components/scoreboard/setLeftStartTeam.tsx
+++ b/src/components/scoreboard/setLeftStartTeam.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { addEvent } from '../../store/match/reducer';
 import { useAppDispatch, useAppSelector } from '../../store/store';
 import { TeamType } from '../types';
-import { getInitials } from "../../util/names";
+import { getInitials, withJerseyNumber } from "../../util/names";
 import { setLeftStartTeamEvent, setNoSideSwitchEvent } from "../eventFunctions";
 import { matchState } from "../../store/types";
 import { getTextColorFromBackground } from "../../util/color";
@@ -38,6 +38,14 @@ export function SetLeftStartTeam() {
         }
     };
 
+    const getPlayerNumber = (match: matchState, playerId: number, teamType: TeamType): string | undefined => {
+        if (teamType === TeamType.Home) {
+            return playerId === 1 ? match.homeTeam.player1Number : match.homeTeam.player2Number;
+        } else {
+            return playerId === 1 ? match.awayTeam.player1Number : match.awayTeam.player2Number;
+        }
+    };
+
     return (
         <Box sx={{ backgroundColor: colors.pageBg, minHeight: "100vh", px: { xs: 2, sm: 4 }, py: 4 }}>
 
@@ -59,15 +67,15 @@ export function SetLeftStartTeam() {
             <Box sx={{ display: "flex", gap: 2, mb: 4 }}>
                 <TeamButton
                     label={[
-                        getInitials(getPlayer(match, 1, getLeftTeam())),
-                        getInitials(getPlayer(match, 2, getLeftTeam())),
+                        withJerseyNumber(getInitials(getPlayer(match, 1, getLeftTeam())), getPlayerNumber(match, 1, getLeftTeam())),
+                        withJerseyNumber(getInitials(getPlayer(match, 2, getLeftTeam())), getPlayerNumber(match, 2, getLeftTeam())),
                     ]}
                     color={match.teamColor[getLeftTeam()]}
                 />
                 <TeamButton
                     label={[
-                        getInitials(getPlayer(match, 1, getRightTeam())),
-                        getInitials(getPlayer(match, 2, getRightTeam())),
+                        withJerseyNumber(getInitials(getPlayer(match, 1, getRightTeam())), getPlayerNumber(match, 1, getRightTeam())),
+                        withJerseyNumber(getInitials(getPlayer(match, 2, getRightTeam())), getPlayerNumber(match, 2, getRightTeam())),
                     ]}
                     color={match.teamColor[getRightTeam()]}
                 />

--- a/src/components/scoreboard/teamColorPicker.tsx
+++ b/src/components/scoreboard/teamColorPicker.tsx
@@ -6,6 +6,7 @@ import { getTextColorFromBackground } from "../../util/color";
 import { addEvent, setTeamColor } from "../../store/match/reducer";
 import { pickTeamColorEvent } from "../eventFunctions";
 import { colors } from "../../theme";
+import { withJerseyNumber } from "../../util/names";
 
 interface TeamColorPickerProps {
     team: TeamType;
@@ -43,6 +44,8 @@ export function TeamColorPicker({ team }: TeamColorPickerProps) {
 
     const player1 = team === TeamType.Home ? match.homeTeam.player1Name : match.awayTeam.player1Name;
     const player2 = team === TeamType.Home ? match.homeTeam.player2Name : match.awayTeam.player2Name;
+    const player1Number = team === TeamType.Home ? match.homeTeam.player1Number : match.awayTeam.player1Number;
+    const player2Number = team === TeamType.Home ? match.homeTeam.player2Number : match.awayTeam.player2Number;
 
     return (
         <Box sx={{ backgroundColor: colors.pageBg, minHeight: "100vh", px: { xs: 2, sm: 4 }, py: 4 }}>
@@ -70,7 +73,7 @@ export function TeamColorPicker({ team }: TeamColorPickerProps) {
                     mb: 3,
                 }}
             >
-                {player1}<br />{player2}
+                {withJerseyNumber(player1, player1Number)}<br />{withJerseyNumber(player2, player2Number)}
             </Typography>
 
             {/* Color grid */}

--- a/src/components/serveOrder.tsx
+++ b/src/components/serveOrder.tsx
@@ -7,7 +7,7 @@ import { addEvent } from '../store/match/reducer';
 import { useAppDispatch, useAppSelector } from '../store/store';
 import { TeamType, Event, EventType } from './types';
 import Grid from "@mui/material/Grid"
-import { getInitials } from "../util/names";
+import { getInitials, withJerseyNumber } from "../util/names";
 import { selectFirstServerEvent, selectFirstServingTeamEvent } from "./eventFunctions";
 import { matchState } from "../store/types";
 import { getTextColorFromBackground } from "../util/color";
@@ -38,8 +38,8 @@ export function ServeOrder() {
           <Box sx={{ flex: 1, display: showServer(match, TeamType.Home, 0) }}>
             <TeamButton
               label={[
-                getInitials(match.homeTeam.player1Name),
-                getInitials(match.homeTeam.player2Name),
+                withJerseyNumber(getInitials(match.homeTeam.player1Name), match.homeTeam.player1Number),
+                withJerseyNumber(getInitials(match.homeTeam.player2Name), match.homeTeam.player2Number),
               ]}
               color={match.teamColor[TeamType.Home]}
               disabled={match.firstServerTeam !== TeamType.None}
@@ -49,8 +49,8 @@ export function ServeOrder() {
           <Box sx={{ flex: 1, display: showServer(match, TeamType.Away, 0) }}>
             <TeamButton
               label={[
-                getInitials(match.awayTeam.player1Name),
-                getInitials(match.awayTeam.player2Name),
+                withJerseyNumber(getInitials(match.awayTeam.player1Name), match.awayTeam.player1Number),
+                withJerseyNumber(getInitials(match.awayTeam.player2Name), match.awayTeam.player2Number),
               ]}
               color={match.teamColor[TeamType.Away]}
               disabled={match.firstServerTeam !== TeamType.None}
@@ -65,7 +65,7 @@ export function ServeOrder() {
         <Box sx={{ display: "flex", gap: 2 }}>
           <Box sx={{ flex: 1, display: showServer(match, TeamType.Home, 1) }}>
             <TeamButton
-              label={[getInitials(match.homeTeam.player1Name)]}
+              label={[withJerseyNumber(getInitials(match.homeTeam.player1Name), match.homeTeam.player1Number)]}
               color={match.teamColor[TeamType.Home]}
               disabled={match.firstServer[TeamType.Home] !== 0}
               onClick={() => setHomeServer(1)}
@@ -73,7 +73,7 @@ export function ServeOrder() {
           </Box>
           <Box sx={{ flex: 1, display: showServer(match, TeamType.Home, 2) }}>
             <TeamButton
-              label={[getInitials(match.homeTeam.player2Name)]}
+              label={[withJerseyNumber(getInitials(match.homeTeam.player2Name), match.homeTeam.player2Number)]}
               color={match.teamColor[TeamType.Home]}
               disabled={match.firstServer[TeamType.Home] !== 0}
               onClick={() => setHomeServer(2)}
@@ -87,7 +87,7 @@ export function ServeOrder() {
         <Box sx={{ display: "flex", gap: 2 }}>
           <Box sx={{ flex: 1, display: showServer(match, TeamType.Away, 1) }}>
             <TeamButton
-              label={[getInitials(match.awayTeam.player1Name)]}
+              label={[withJerseyNumber(getInitials(match.awayTeam.player1Name), match.awayTeam.player1Number)]}
               color={match.teamColor[TeamType.Away]}
               disabled={match.firstServer[TeamType.Away] !== 0}
               onClick={() => setAwayServer(1)}
@@ -95,7 +95,7 @@ export function ServeOrder() {
           </Box>
           <Box sx={{ flex: 1, display: showServer(match, TeamType.Away, 2) }}>
             <TeamButton
-              label={[getInitials(match.awayTeam.player2Name)]}
+              label={[withJerseyNumber(getInitials(match.awayTeam.player2Name), match.awayTeam.player2Number)]}
               color={match.teamColor[TeamType.Away]}
               disabled={match.firstServer[TeamType.Away] !== 0}
               onClick={() => setAwayServer(2)}

--- a/src/components/types.tsx
+++ b/src/components/types.tsx
@@ -3,6 +3,8 @@ import { v4 } from 'uuid';
 export type Team = {
   player1Name: string
   player2Name: string
+  player1Number?: string
+  player2Number?: string
 }
 
 export type Set = {

--- a/src/firebase/match_service.tsx
+++ b/src/firebase/match_service.tsx
@@ -90,10 +90,14 @@ export const getMatch = async (
     homeTeam: {
       player1Name: "",
       player2Name: "",
+      player1Number: "",
+      player2Number: "",
     },
     awayTeam: {
       player1Name: "",
       player2Name: "",
+      player1Number: "",
+      player2Number: "",
     },
     homeColor: "",
     awayColor: "",

--- a/src/pages/CreateMatch.tsx
+++ b/src/pages/CreateMatch.tsx
@@ -20,6 +20,10 @@ function Match() {
   const homePlayer2 = searchParams.get('name2');
   const awayPlayer1 = searchParams.get('name3');
   const awayPlayer2 = searchParams.get('name4');
+  const homePlayer1Number = searchParams.get('number1');
+  const homePlayer2Number = searchParams.get('number2');
+  const awayPlayer1Number = searchParams.get('number3');
+  const awayPlayer2Number = searchParams.get('number4');
   const matchId = searchParams.get('matchId');
   const tournamentId = searchParams.get('tournamentId');
 
@@ -35,6 +39,8 @@ function Match() {
     dispatch(addHomeTeam({
       player1Name: homePlayer1,
       player2Name: homePlayer2,
+      player1Number: homePlayer1Number ?? undefined,
+      player2Number: homePlayer2Number ?? undefined,
     }))
   }
 
@@ -42,6 +48,8 @@ function Match() {
     dispatch(addAwayTeam({
       player1Name: awayPlayer1,
       player2Name: awayPlayer2,
+      player1Number: awayPlayer1Number ?? undefined,
+      player2Number: awayPlayer2Number ?? undefined,
     }))
   }
 

--- a/src/store/match/reducer.ts
+++ b/src/store/match/reducer.ts
@@ -19,10 +19,14 @@ export const initMatchState: matchState = {
   homeTeam: {
     player1Name: "",
     player2Name: "",
+    player1Number: "",
+    player2Number: "",
   },
   awayTeam: {
     player1Name: "",
     player2Name: "",
+    player1Number: "",
+    player2Number: "",
   },
   teamColor: { "HOME": "", "AWAY": "" },
   matchId: "null",

--- a/src/util/names.tsx
+++ b/src/util/names.tsx
@@ -17,3 +17,7 @@ export function getInitials(names: string) {
 
     return result;
 }
+
+export function withJerseyNumber(label: string, jerseyNumber?: string): string {
+    return jerseyNumber ? `#${jerseyNumber} ${label}` : label;
+}

--- a/tests/match-reducer.test.ts
+++ b/tests/match-reducer.test.ts
@@ -72,6 +72,20 @@ describe("matchReducer — basic actions", () => {
         expect(state.awayTeam).toEqual(team);
     });
 
+    it("addHomeTeam stores jersey numbers when present", () => {
+        const team = { player1Name: "Alice", player2Name: "Bob", player1Number: "7", player2Number: "12" };
+        const state = matchReducer(initMatchState, addHomeTeam(team));
+        expect(state.homeTeam.player1Number).toBe("7");
+        expect(state.homeTeam.player2Number).toBe("12");
+    });
+
+    it("addAwayTeam stores jersey numbers when present", () => {
+        const team = { player1Name: "Carol", player2Name: "Dave", player1Number: "3", player2Number: "9" };
+        const state = matchReducer(initMatchState, addAwayTeam(team));
+        expect(state.awayTeam.player1Number).toBe("3");
+        expect(state.awayTeam.player2Number).toBe("9");
+    });
+
     it("setId stores match document id", () => {
         const state = matchReducer(initMatchState, setId("doc-abc"));
         expect(state.id).toBe("doc-abc");

--- a/tests/names.test.ts
+++ b/tests/names.test.ts
@@ -1,0 +1,15 @@
+import { withJerseyNumber } from "../src/util/names";
+
+describe("withJerseyNumber", () => {
+    it("prefixes the label with the jersey number when present", () => {
+        expect(withJerseyNumber("J. Doe", "7")).toBe("#7 J. Doe");
+    });
+
+    it("returns the label unchanged when jersey number is undefined", () => {
+        expect(withJerseyNumber("J. Doe", undefined)).toBe("J. Doe");
+    });
+
+    it("returns the label unchanged when jersey number is an empty string", () => {
+        expect(withJerseyNumber("J. Doe", "")).toBe("J. Doe");
+    });
+});


### PR DESCRIPTION
Add an optional shirt/jersey number field for each player in the manual scoreboard flow (Add Team form, URL query-param prefill), stored alongside player names in Firestore and shown next to initials wherever players are displayed (scoreboard, serve-order picker, side picker, color picker, match-start confirmation). Purely optional, no validation tied to competition type.

---

Koden her er ganske rett fra. Vet ikke om jeg hadde løst det på samme måte men Claude har følgt den strukturen som lå der.

Vært å merke seg. Query parameteret for å legge til spiller navn er:
player1, player2, player3, player4. 

Claude har følgt denne på draktnummer. Det er nå:
number1, number2, number3, number4

Både litt idiotisk, og ganske enkelt å huske.. jeg retta ikke på det. 

Lov å ville ha endringer! bare si i fra :)   