### PR TITLE
feat: keep the screen on while officiating via Screen Wake Lock API

### DIFF
--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -58,6 +58,32 @@ function Match() {
     return () => clearInterval(intervalId);
   }, [match]);
 
+  useEffect(() => {
+    if (!('wakeLock' in navigator)) return;
+    let sentinel: WakeLockSentinel | null = null;
+
+    const requestLock = async () => {
+      try {
+        sentinel = await navigator.wakeLock.request('screen');
+      } catch (error) {
+        console.error('Error:', error);
+      }
+    };
+    requestLock();
+
+    // The wake lock is auto-released when the tab is hidden, so
+    // re-acquire it once the referee comes back to the app.
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') requestLock();
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      sentinel?.release();
+    };
+  }, []);
+
   if (!match.id && params.matchId) {
     console.log('set match id : %s', params.matchId)
     dispatch(setId(params.matchId))


### PR DESCRIPTION
The screen would turn off mid-match while a referee was scoring. Request a screen wake lock for the lifetime of the match view, feature-detected since Wake Lock support (notably Safari) is inconsistent and there's no browserslist/PWA config to gate on. Re-acquires on visibilitychange since the OS releases the lock whenever the tab is hidden.

-----

Dette er featurene jeg er mest usikker på om vi skal ha med. Jeg synes det var irriternede at den slo seg av, men samtidig tar dette mer strøm. Jeg vet ikke hvor stort problem vi har med at mobiler nesten er tom for strøm på turneringer, og jeg vet heller ikke hvor mye mer strøm dette vil bruke. 

Dog er det slik at OS kan overstyre dette etter eget ønsker, og slik jeg tolker ChatGPT stopper denne featuren når den går inn i sparemodus.