### PR TITLE
Technical timeout color indicator

### DIFF
--- a/src/components/scoreboard/teamTimeout.tsx
+++ b/src/components/scoreboard/teamTimeout.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { EventType, TeamType } from "../types";
 import { Box, Button, Typography } from "@mui/material";
 import { useAppDispatch, useAppSelector } from '../../store/store';
 import { addEvent } from "../../store/match/reducer";
 import TimeElapsed from "../timeElaped";
 import { setClearMessageEvent } from "../eventFunctions";
-import { colors } from "../../theme";
+import { colors, getTimeoutTimerColor } from "../../theme";
 
 interface TeamTimeoutProps {
     team: TeamType;
@@ -14,12 +14,14 @@ interface TeamTimeoutProps {
 export function TeamTimeout({ team }: TeamTimeoutProps) {
     const dispatch = useAppDispatch();
     const match = useAppSelector((state) => state.match);
+    const [elapsedSeconds, setElapsedSeconds] = useState(0);
 
     function handleDone() {
         dispatch(addEvent({ matchId: match.matchId, id: match.id, event: setClearMessageEvent(match.authUserId) }));
     }
 
     const timeoutEvent = match.events.slice().reverse().find(e => e.eventType === EventType.Timeout && !e.undone);
+    const timerColor = getTimeoutTimerColor(elapsedSeconds);
 
     return (
         <Box sx={{ backgroundColor: colors.pageBg, minHeight: "100vh", px: { xs: 2, sm: 4 }, py: 4 }}>
@@ -43,14 +45,14 @@ export function TeamTimeout({ team }: TeamTimeoutProps) {
                 sx={{
                     fontSize: { xs: "48px", sm: "64px" },
                     fontWeight: 600,
-                    color: colors.textPrimary,
+                    color: timerColor,
                     textAlign: "center",
                     fontFamily: "'DM Mono', monospace",
                     lineHeight: 1,
                     mb: 4,
                 }}
             >
-                <TimeElapsed startTime={timeoutEvent?.timestamp || 0} />
+                <TimeElapsed startTime={timeoutEvent?.timestamp || 0} onTick={setElapsedSeconds} />
             </Typography>
 
             {/* Done button */}

--- a/src/components/scoreboard/technicalTimeout.tsx
+++ b/src/components/scoreboard/technicalTimeout.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Box, Button, Typography } from "@mui/material";
 import { useAppDispatch, useAppSelector } from '../../store/store';
 import { addEvent } from "../../store/match/reducer";
@@ -10,13 +10,25 @@ interface TechnicalTimeoutProps {
     startTime: number;
 }
 
+// FIVB referee procedure: 30s is the timeout itself, the 2nd referee
+// should whistle players back onto the court at 45s.
+const TECHNICAL_TIMEOUT_WARNING_SECONDS = 30;
+const TECHNICAL_TIMEOUT_OVERDUE_SECONDS = 45;
+
 export function TechnicalTimeout({ startTime }: TechnicalTimeoutProps) {
     const dispatch = useAppDispatch();
     const match = useAppSelector((state) => state.match);
+    const [elapsedSeconds, setElapsedSeconds] = useState(0);
 
     function handleDone() {
         dispatch(addEvent({ matchId: match.matchId, id: match.id, event: setClearMessageEvent(match.authUserId) }));
     }
+
+    const timerColor = elapsedSeconds >= TECHNICAL_TIMEOUT_OVERDUE_SECONDS
+        ? colors.timeoutOverdue
+        : elapsedSeconds >= TECHNICAL_TIMEOUT_WARNING_SECONDS
+            ? colors.timeoutWarning
+            : colors.textPrimary;
 
     return (
         <Box sx={{ backgroundColor: colors.pageBg, minHeight: "100vh", px: { xs: 2, sm: 4 }, py: 4 }}>
@@ -40,14 +52,14 @@ export function TechnicalTimeout({ startTime }: TechnicalTimeoutProps) {
                 sx={{
                     fontSize: { xs: "48px", sm: "64px" },
                     fontWeight: 600,
-                    color: colors.textPrimary,
+                    color: timerColor,
                     textAlign: "center",
                     fontFamily: "'DM Mono', monospace",
                     lineHeight: 1,
                     mb: 4,
                 }}
             >
-                <TimeElapsed startTime={startTime} />
+                <TimeElapsed startTime={startTime} onTick={setElapsedSeconds} />
             </Typography>
 
             {/* Done button */}

--- a/src/components/scoreboard/technicalTimeout.tsx
+++ b/src/components/scoreboard/technicalTimeout.tsx
@@ -4,16 +4,11 @@ import { useAppDispatch, useAppSelector } from '../../store/store';
 import { addEvent } from "../../store/match/reducer";
 import { setClearMessageEvent } from "../eventFunctions";
 import TimeElapsed from "../timeElaped";
-import { colors } from "../../theme";
+import { colors, getTimeoutTimerColor } from "../../theme";
 
 interface TechnicalTimeoutProps {
     startTime: number;
 }
-
-// FIVB referee procedure: 30s is the timeout itself, the 2nd referee
-// should whistle players back onto the court at 45s.
-const TECHNICAL_TIMEOUT_WARNING_SECONDS = 30;
-const TECHNICAL_TIMEOUT_OVERDUE_SECONDS = 45;
 
 export function TechnicalTimeout({ startTime }: TechnicalTimeoutProps) {
     const dispatch = useAppDispatch();
@@ -24,11 +19,7 @@ export function TechnicalTimeout({ startTime }: TechnicalTimeoutProps) {
         dispatch(addEvent({ matchId: match.matchId, id: match.id, event: setClearMessageEvent(match.authUserId) }));
     }
 
-    const timerColor = elapsedSeconds >= TECHNICAL_TIMEOUT_OVERDUE_SECONDS
-        ? colors.timeoutOverdue
-        : elapsedSeconds >= TECHNICAL_TIMEOUT_WARNING_SECONDS
-            ? colors.timeoutWarning
-            : colors.textPrimary;
+    const timerColor = getTimeoutTimerColor(elapsedSeconds);
 
     return (
         <Box sx={{ backgroundColor: colors.pageBg, minHeight: "100vh", px: { xs: 2, sm: 4 }, py: 4 }}>

--- a/src/components/timeElaped.tsx
+++ b/src/components/timeElaped.tsx
@@ -4,9 +4,10 @@ import moment from "moment";
 
 interface Props {
   startTime: number;
+  onTick?: (elapsedSeconds: number) => void;
 }
 
-const TimeElapsed: React.FC<Props> = ({ startTime }) => {
+const TimeElapsed: React.FC<Props> = ({ startTime, onTick }) => {
   const [time, setTime] = useState<string>("00:00");
 
   useEffect(() => {
@@ -33,10 +34,11 @@ const TimeElapsed: React.FC<Props> = ({ startTime }) => {
       }
 
       setTime(formattedTime);
+      onTick?.(elapsed.asSeconds());
     }, 1000);
 
     return () => clearInterval(intervalId);
-  }, [startTime]);
+  }, [startTime, onTick]);
 
   return (
     <div>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -73,6 +73,10 @@ export const colors = {
     reportedStatusBg: "#f5edbc",
     reportedStatusText: "#6a5800",
     reportedDot: "#c8a800",
+
+    // Technical timeout: elapsed-time escalation
+    timeoutWarning: "#c8a800", // time's up, players should be returning
+    timeoutOverdue: "#c0392b", // 2nd referee should already have whistled
 } as const;
 
 // ─── Theme ───────────────────────────────────────────────────────────────────

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -74,10 +74,22 @@ export const colors = {
     reportedStatusText: "#6a5800",
     reportedDot: "#c8a800",
 
-    // Technical timeout: elapsed-time escalation
+    // Timeouts (team + technical): elapsed-time escalation
     timeoutWarning: "#c8a800", // time's up, players should be returning
     timeoutOverdue: "#c0392b", // 2nd referee should already have whistled
 } as const;
+
+// FIVB referee procedure: 30s is the timeout itself, the 2nd referee
+// should whistle players back onto the court at 45s. Applies to both
+// team timeouts and technical timeouts.
+export const TIMEOUT_WARNING_SECONDS = 30;
+export const TIMEOUT_OVERDUE_SECONDS = 45;
+
+export function getTimeoutTimerColor(elapsedSeconds: number): string {
+    if (elapsedSeconds >= TIMEOUT_OVERDUE_SECONDS) return colors.timeoutOverdue;
+    if (elapsedSeconds >= TIMEOUT_WARNING_SECONDS) return colors.timeoutWarning;
+    return colors.textPrimary;
+}
 
 // ─── Theme ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Dette er PRen som kanksje har best kode. 

Dog er det også PRen hvor jeg er mest usikker på hva som er best måte og løse dette på.

en timeout (både teknisk og vanlig) er 30 sek. 

FIVB sine "dommer praksis håndbok" sier følgende:
spillerne har 15 sek til å gå av banen
spillerne har 30 sekunder timeout
spillernee har 15 sekunder til å gå på banene igjen og spillet skal dermed starte etter 1 min. 

Det som er implementert er 30 sekunder vanlig. 
15 sekunder gult
så rødt.   

Spørmålet er litt hvor lang tid det tar før man trykker timneout i appen. 

Dette kan nok også løses ved forklarende tekst... heller litt mot at det er beste løsning i tillegg til å vise 15+30. Det viktigste poenget er at det skal blåses inn på banen etter 45 sek tenker jeg. Det bør vel være den praktiske regelen i RT/NT etc... 