### PR TITLE
fix: confirm before leaving an in-progress match

### DIFF
--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -58,6 +58,35 @@ function Match() {
     return () => clearInterval(intervalId);
   }, [match]);
 
+  useEffect(() => {
+    if (match.finished) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [match.finished]);
+
+  useEffect(() => {
+    if (match.finished) return;
+
+    // Push a sentinel history entry so a back navigation triggers popstate
+    // instead of immediately leaving the match.
+    window.history.pushState(null, '', window.location.href);
+
+    const handlePopState = () => {
+      if (window.confirm('Leave the match? You will need to reopen it to continue scoring.')) {
+        window.history.back();
+      } else {
+        window.history.pushState(null, '', window.location.href);
+      }
+    };
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [match.finished]);
+
   if (!match.id && params.matchId) {
     console.log('set match id : %s', params.matchId)
     dispatch(setId(params.matchId))


### PR DESCRIPTION
Add a beforeunload prompt for tab close/refresh/typed URL, and a popstate-based confirm dialog for in-app back navigation (browser back button / Android back gesture), since the app uses classic react-router (no data router / useBlocker available). Both are gated on the match not being finished, so completed matches are unaffected.
-----

Verdt å merke seg: 
Det er noe browser spam protection  greier sånn man ikke kan "hooke" seg på som en spam side og nekte deg å komme vekk. 
Jeg får ikke spørsmål om å stoppe og navigere bort før 4-5 poeng har gått. Men etter det spør den alltid.  Tenker det er mye bedre enn at den ikke gjør det i det hele tatt
